### PR TITLE
Add site context to elements possibly affecting distribution of metrics

### DIFF
--- a/draft/a-unified-theory-of-web-performance.md
+++ b/draft/a-unified-theory-of-web-performance.md
@@ -80,6 +80,7 @@ The cost of JavaScript is not only the time it takes to load your bundle. The ti
   - Phone device: iPhone 5, Samsung, etc
   - Operating System
   - Browser
+  - Site context (consent popin, A/B tests, ...)
 - Not all metrics are equally important
   - Common metrics: TTI, FID, LCP, TBT, CLS, Speed Index, custom metrics
   - For Netflix TV UI, key input responsiveness, memory usage and TTI are more critical, and for Wikipedia, first/last visual changes and CPU time spent metrics are more important.


### PR DESCRIPTION
There are other elements affecting the distribution of metrics.
For instance, users can be separated between those who see a consent popin (may affect LCP/CLS) and those whou don't. Same for users affected by the result of an A/B test. 